### PR TITLE
Add Atlas Commons corporate liability disclaimer and DCO

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing to Atlas Commons
+
+Thank you for contributing to this Atlas Commons project.
+
+## Developer Certificate of Origin (DCO)
+
+By contributing to this repository, you agree to the [Developer Certificate of Origin (DCO)](./DCO).
+
+Every commit must include a sign-off line. Use:
+
+```bash
+git commit -s -m "Your commit message"
+```
+
+This adds a `Signed-off-by` trailer in the form:
+
+```
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+The sign-off certifies that you have the right to submit the work under the project's license and that you agree to the DCO.
+
+## Corporate disclaimer
+
+This project is part of **Atlas Commons**, managed and financed by **Atlas Tech Solutions Ltd**. See [CORPORATE-LIABILITY-DISCLAIMER.md](./CORPORATE-LIABILITY-DISCLAIMER.md) for the corporate liability disclaimer.
+
+## Pull requests
+
+1. Fork the repository and create a branch from the default branch.
+2. Make your changes with clear, focused commits (each signed off with `-s`).
+3. Open a pull request describing what changed and why.
+4. Ensure your changes comply with the project license and any applicable platform rules (for example, Steam Workshop or Bohemia Interactive guidelines for Arma 3 mods).

--- a/CORPORATE-LIABILITY-DISCLAIMER.md
+++ b/CORPORATE-LIABILITY-DISCLAIMER.md
@@ -1,0 +1,31 @@
+# Corporate Liability Disclaimer
+
+**Last updated: 22 May 2026**
+
+**Atlas Commons** is a community software and content program **managed and financed by Atlas Tech Solutions Ltd** (registered in England and Wales).
+
+While Atlas Tech Solutions Ltd provides administrative, financial, and infrastructure support to the Atlas Commons program, **Atlas Tech Solutions Ltd is not responsible or liable for the software, content, or services** distributed under the Atlas Commons name, except to the extent expressly stated in the applicable license for a specific work.
+
+## No warranty
+
+All Atlas Commons projects are provided **"AS IS"** and **"AS AVAILABLE"**, without warranty of any kind, whether express or implied, including but not limited to warranties of merchantability, fitness for a particular purpose, title, and non-infringement.
+
+## Limitation of liability
+
+**To the maximum extent permitted by applicable law**, Atlas Tech Solutions Ltd and its directors, officers, employees, contractors, agents, and affiliates **shall not be liable** for any direct, indirect, incidental, special, consequential, exemplary, or punitive damages, or any loss of profits, revenue, data, goodwill, or other intangible losses, arising from or related to:
+
+- your access to, use of, or inability to use any Atlas Commons project;
+- any conduct or content of any third party in connection with an Atlas Commons project; or
+- unauthorized access to, or alteration of, your transmissions or content.
+
+This applies even if Atlas Tech Solutions Ltd has been advised of the possibility of such damages.
+
+## Relationship to project licenses
+
+This disclaimer **supplements** the warranty and liability terms in each project's license (for example, the Atlas Commons EULA or GNU GPL). Where a project license assigns liability to a licensor or author, that allocation applies to the licensor or author identified in that license. **Atlas Tech Solutions Ltd does not assume that liability by virtue of managing or financing the Atlas Commons program.**
+
+## Your responsibility
+
+Your use of Atlas Commons projects is at your sole risk. You are responsible for ensuring that your use complies with the applicable license and with all laws and platform rules that apply to you.
+
+For questions about a specific project, use that project's issue tracker or the official Atlas Commons Discord.

--- a/DCO
+++ b/DCO
@@ -1,0 +1,34 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-	<img src="https://github.com/Viking-Studios-Arma/ONI_Recon_Essentials/blob/5d17ad1523638d20144793f82f990c9eececcb5a/Falcon%20flight%20banner%20W-logo.png" alt="ONI Recon Banner Banner" />
+	<img src="https://github.com/Atlas-Commons/ONI_Recon_Essentials/blob/5d17ad1523638d20144793f82f990c9eececcb5a/Falcon%20flight%20banner%20W-logo.png" alt="ONI Recon Banner Banner" />
 	<br />
 	<a href="https://discord.gg/9pJTHHzaFC">
 		<img src="https://img.shields.io/discord/1032437213100777502.svg?label=Discord&logo=Discord&colorB=7289da&style=for-the-badge" alt="Discord Server">
@@ -14,14 +14,14 @@
 	<a href="https://steamcommunity.com/sharedfiles/filedetails/?id=3016023028">
 		<img src="https://img.shields.io/steam/size/3108371604?label=Download&logo=steam" alt="Download" />
 	</a>
-	<a href="https://github.com/Viking-Studios-Arma/Backpack-Drones/releases">
-		<img src="https://img.shields.io/github/release/Viking-Studios-Arma/Backpack-Drones.svg?label=Version" alt="Version" />
+	<a href="https://github.com/Atlas-Commons/Backpack-Drones/releases">
+		<img src="https://img.shields.io/github/release/Atlas-Commons/Backpack-Drones.svg?label=Version" alt="Version" />
 	</a>
-	<a href="https://github.com/Viking-Studios-Arma/Backpack-Drones/issues">
-		<img src="http://img.shields.io/github/issues-raw/Viking-Studios-Arma/Backpack-Drones?label=Issues&style=flat" alt="Issues" />
+	<a href="https://github.com/Atlas-Commons/Backpack-Drones/issues">
+		<img src="http://img.shields.io/github/issues-raw/Atlas-Commons/Backpack-Drones?label=Issues&style=flat" alt="Issues" />
 	</a>
-	<a href="Viking-Studios-Arma/Backpack-Drones/blob/main/LICENSE">
-		<img src="https://img.shields.io/github/license/Viking-Studios-Arma/Backpack-Drones.svg?style=flat&label=Licence" alt="License">
+	<a href="Atlas-Commons/Backpack-Drones/blob/main/LICENSE">
+		<img src="https://img.shields.io/github/license/Atlas-Commons/Backpack-Drones.svg?style=flat&label=Licence" alt="License">
 	</a>
 </p>
 
@@ -65,4 +65,16 @@ Be aware, that the names of the `.bisign` and `.bikey` files depend on the lates
 ## Naming conventions
 For standardisation between class names and to prevent any possible future conflicts with class names the following naming convention has been developed:
 - for code: VS_Core
-- for presentation: Viking Studios - {Addon Name}
+- for presentation: Atlas Commons - {Addon Name}
+
+---
+
+## Atlas Commons — legal notices
+
+This project is part of **Atlas Commons**, managed and financed by **Atlas Tech Solutions Ltd**. **Atlas Tech Solutions Ltd is not responsible or liable for this software** except as expressly stated in the applicable license.
+
+| Document | Purpose |
+|----------|---------|
+| [CORPORATE-LIABILITY-DISCLAIMER.md](./CORPORATE-LIABILITY-DISCLAIMER.md) | Corporate sponsor liability disclaimer |
+| [DCO](./DCO) | Developer Certificate of Origin (required for contributions) |
+| [CONTRIBUTING.md](./CONTRIBUTING.md) | Contribution guidelines and DCO sign-off |


### PR DESCRIPTION
Adds CORPORATE-LIABILITY-DISCLAIMER.md, DCO, CONTRIBUTING.md, and README/license updates documenting that Atlas Tech Solutions Ltd manages and finances Atlas Commons but is not responsible or liable for the software.